### PR TITLE
Added mediafield as requirement to composer.json and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # SilverStripe Elemental Media
 
+## Requirements
+
+* silverstripe/cms ^4.0
+* thewebmen/silverstripe-media-field ^1.1
+
 ## Description
 Media element for Elemental containing a video or photo

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "prefer-stable": true,
     "require": {
         "silverstripe/cms": "^4.0@dev",
-        "silverstripe/vendor-plugin": "^1.0"
+        "silverstripe/vendor-plugin": "^1.0",
+        "thewebmen/silverstripe-media-field": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
This MR adds `thewebmen/silverstripe-media-field` as dependency to this project.

## Test steps:

- [x] The best is to find a project where this module is not installed
- [x] `composer require thewebmen/silverstripe-elemental-media:dev-feature/media-field-requirement`
- [x] `composer show -i | grep media` and verify that `thewebmen/silverstripe-media-field` is also installed