### PR TITLE
FIX: Add type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "wedevelopnl/silverstripe-elemental-media",
     "description": "Elemental media module",
+    "type": "silverstripe-vendormodule",
     "keywords": [
         "silverstripe",
         "elemental",


### PR DESCRIPTION
add     "type": "silverstripe-vendormodule", to ensure it is listed on ssmods.com.